### PR TITLE
IMAP IDLE — real-time push notifications for folders

### DIFF
--- a/src/app_event.rs
+++ b/src/app_event.rs
@@ -60,6 +60,12 @@ pub enum AppEvent {
         body: MessageBody,
     },
 
+    /// IDLE or poll detected changes in a folder — trigger differential sync.
+    IdleNotification {
+        account_id: String,
+        folder_name: String,
+    },
+
     /// User selected a folder in the sidebar.
     FolderSelected {
         account_id: String,

--- a/src/app_event.rs
+++ b/src/app_event.rs
@@ -66,6 +66,17 @@ pub enum AppEvent {
         folder_name: String,
     },
 
+    /// IDLE detected a flag change on a specific message — update directly.
+    IdleFlagsChanged {
+        account_id: String,
+        folder_name: String,
+        uid: u32,
+        is_read: bool,
+        is_flagged: bool,
+        is_answered: bool,
+        is_draft: bool,
+    },
+
     /// User selected a folder in the sidebar.
     FolderSelected {
         account_id: String,

--- a/src/engine/db/messages.rs
+++ b/src/engine/db/messages.rs
@@ -24,6 +24,7 @@ pub struct MessageRow {
     pub preview: Option<String>,
     pub content_type: Option<String>,
     pub has_attachments: bool,
+    pub has_body: bool,
     pub internal_date: Option<String>,
 }
 
@@ -67,7 +68,7 @@ const MESSAGE_COLUMNS: &str =
     "id, uuid, account_id, folder_name, uid, message_id, subject, sender,
      to_addresses, cc_addresses, date, in_reply_to, reference_ids,
      is_read, is_flagged, is_answered, is_draft,
-     preview, content_type, has_attachments, internal_date";
+     preview, content_type, has_attachments, has_body, internal_date";
 
 impl Database {
     /// Bulk upsert messages for a folder within a transaction. Skips rows where
@@ -322,6 +323,45 @@ impl Database {
         .execute(self.pool())
         .await?;
         Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a message as having its body downloaded.
+    pub async fn mark_body_downloaded(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE messages SET has_body = 1
+             WHERE account_id = ? AND folder_name = ? AND uid = ?",
+        )
+        .bind(account_id)
+        .bind(folder_name)
+        .bind(uid)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    /// Get uuid, uid for messages within the prefetch window that are missing bodies.
+    pub async fn list_missing_bodies(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        since: &str,
+    ) -> Result<Vec<(String, i64)>, DbError> {
+        let rows = sqlx::query_as::<_, (String, i64)>(
+            "SELECT uuid, uid FROM messages
+             WHERE account_id = ? AND folder_name = ? AND has_body = 0
+             AND (internal_date >= ? OR internal_date IS NULL)",
+        )
+        .bind(account_id)
+        .bind(folder_name)
+        .bind(since)
+        .fetch_all(self.pool())
+        .await?;
+        Ok(rows)
     }
 
     /// Delete messages by UID. Returns the number of rows deleted.

--- a/src/engine/db/messages.rs
+++ b/src/engine/db/messages.rs
@@ -292,6 +292,38 @@ impl Database {
         Ok(rows.into_iter().map(|(uid,)| uid as u32).collect())
     }
 
+    /// Update flags for a single message. Returns true if the row was changed.
+    pub async fn update_flags(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+        is_read: bool,
+        is_flagged: bool,
+        is_answered: bool,
+        is_draft: bool,
+    ) -> Result<bool, DbError> {
+        let result = sqlx::query(
+            "UPDATE messages SET is_read = ?, is_flagged = ?, is_answered = ?, is_draft = ?
+             WHERE account_id = ? AND folder_name = ? AND uid = ?
+             AND (is_read != ? OR is_flagged != ? OR is_answered != ? OR is_draft != ?)",
+        )
+        .bind(is_read)
+        .bind(is_flagged)
+        .bind(is_answered)
+        .bind(is_draft)
+        .bind(account_id)
+        .bind(folder_name)
+        .bind(uid)
+        .bind(is_read)
+        .bind(is_flagged)
+        .bind(is_answered)
+        .bind(is_draft)
+        .execute(self.pool())
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Delete messages by UID. Returns the number of rows deleted.
     pub async fn bulk_delete_by_uids(
         &self,

--- a/src/engine/db/migrations/005_create_messages.sql
+++ b/src/engine/db/migrations/005_create_messages.sql
@@ -20,6 +20,7 @@ CREATE TABLE messages (
     preview         TEXT,
     content_type    TEXT,
     has_attachments INTEGER NOT NULL DEFAULT 0,
+    has_body        INTEGER NOT NULL DEFAULT 0,
     content_hash    TEXT,
     UNIQUE(account_id, folder_name, uid),
     UNIQUE(uuid)

--- a/src/engine/messages.rs
+++ b/src/engine/messages.rs
@@ -194,6 +194,39 @@ impl MailMessages for MailMessagesImpl {
         Ok(self.db.list_local_uids(account_id, folder_name).await?)
     }
 
+    async fn update_flags(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+        is_read: bool,
+        is_flagged: bool,
+        is_answered: bool,
+        is_draft: bool,
+    ) -> anyhow::Result<bool> {
+        let changed = self
+            .db
+            .update_flags(account_id, folder_name, uid, is_read, is_flagged, is_answered, is_draft)
+            .await?;
+
+        if changed {
+            let rows = self
+                .db
+                .list_messages_by_uids(account_id, folder_name, &[uid])
+                .await?;
+            if let Some(row) = rows.into_iter().next() {
+                let msg = row_to_message(row);
+                self.sender.send(AppEvent::MessagesUpdated {
+                    account_id: account_id.to_string(),
+                    folder_name: folder_name.to_string(),
+                    messages: vec![msg],
+                });
+            }
+        }
+
+        Ok(changed)
+    }
+
     async fn delete_messages_by_uids(
         &self,
         account_id: &str,

--- a/src/engine/messages.rs
+++ b/src/engine/messages.rs
@@ -177,6 +177,25 @@ impl MailMessages for MailMessagesImpl {
             .collect())
     }
 
+    async fn mark_body_downloaded(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+    ) -> anyhow::Result<()> {
+        Ok(self.db.mark_body_downloaded(account_id, folder_name, uid).await?)
+    }
+
+    async fn list_missing_bodies(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        since: &str,
+    ) -> anyhow::Result<Vec<(String, u32)>> {
+        let rows = self.db.list_missing_bodies(account_id, folder_name, since).await?;
+        Ok(rows.into_iter().map(|(uuid, uid)| (uuid, uid as u32)).collect())
+    }
+
     async fn get_uuid(
         &self,
         account_id: &str,

--- a/src/engine/traits/messages.rs
+++ b/src/engine/traits/messages.rs
@@ -115,6 +115,18 @@ pub trait MailMessages: Send + Sync {
         folder_name: &str,
     ) -> anyhow::Result<std::collections::HashSet<u32>>;
 
+    /// Update flags for a single message by UID. Emits MessagesUpdated if changed.
+    async fn update_flags(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+        is_read: bool,
+        is_flagged: bool,
+        is_answered: bool,
+        is_draft: bool,
+    ) -> anyhow::Result<bool>;
+
     /// Remove messages by UID. Emits MessagesRemoved.
     async fn delete_messages_by_uids(
         &self,

--- a/src/engine/traits/messages.rs
+++ b/src/engine/traits/messages.rs
@@ -92,6 +92,22 @@ pub trait MailMessages: Send + Sync {
         offset: u32,
     ) -> anyhow::Result<Vec<Message>>;
 
+    /// Mark a message as having its body downloaded (.eml on disk).
+    async fn mark_body_downloaded(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        uid: u32,
+    ) -> anyhow::Result<()>;
+
+    /// Get uuid + uid for messages within the prefetch window missing bodies.
+    async fn list_missing_bodies(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+        since: &str,
+    ) -> anyhow::Result<Vec<(String, u32)>>;
+
     /// Get the UUID for a message by its IMAP UID.
     async fn get_uuid(
         &self,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,5 @@
 pub mod body_worker;
+pub mod idle;
 pub mod imap;
 pub mod pool;
 pub mod service;

--- a/src/sync/body_worker.rs
+++ b/src/sync/body_worker.rs
@@ -93,11 +93,24 @@ impl BodyWorker {
     }
 
     async fn fetch_body(&self, req: &FetchBodyRequest) -> anyhow::Result<()> {
+        let t0 = std::time::Instant::now();
+
         // Check if .eml already exists on disk
         if self.body_store.has_eml(&req.account_id, &req.uuid).await {
-            debug!(uid = req.uid, uuid = %req.uuid, "Body already on disk");
+            let t_disk = t0.elapsed();
             if let Some(raw) = self.body_store.read_eml(&req.account_id, &req.uuid).await? {
+                let t_read = t0.elapsed();
                 let body = parse_mime_body(&raw);
+                let t_parse = t0.elapsed();
+                debug!(
+                    uid = req.uid,
+                    bytes = raw.len(),
+                    disk_check_ms = t_disk.as_millis() as u64,
+                    read_ms = (t_read - t_disk).as_millis() as u64,
+                    parse_ms = (t_parse - t_read).as_millis() as u64,
+                    total_ms = t_parse.as_millis() as u64,
+                    "Body served from disk"
+                );
                 self.sender.send(AppEvent::MessageBodyFetched {
                     account_id: req.account_id.clone(),
                     folder_name: req.folder_name.clone(),
@@ -137,10 +150,13 @@ impl BodyWorker {
             folder = %req.folder_name,
             "Fetching body from IMAP"
         );
+        let t_imap_start = t0.elapsed();
         let mut guard = self.pool.acquire(&req.account_id, &config, max_conns).await?;
+        let t_pool = t0.elapsed();
         let session = guard.session();
 
         session.select(&req.folder_name).await?;
+        let t_select = t0.elapsed();
 
         let uid_str = req.uid.to_string();
         let fetches = match session.uid_fetch(&uid_str, "BODY[]").await {
@@ -150,6 +166,7 @@ impl BodyWorker {
                 return Err(e.into());
             }
         };
+        let t_fetch = t0.elapsed();
 
         let raw_bytes = fetches
             .iter()
@@ -161,16 +178,21 @@ impl BodyWorker {
             .store_eml(&req.account_id, &req.uuid, &raw_bytes)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to store .eml: {e}"))?;
+        let t_store = t0.elapsed();
 
         // Parse and emit
         let body = parse_mime_body(&raw_bytes);
+        let t_parse = t0.elapsed();
 
         debug!(
             uid = req.uid,
-            uuid = %req.uuid,
             bytes = raw_bytes.len(),
-            has_html = body.body_html.is_some(),
-            has_text = body.body_text.is_some(),
+            pool_ms = (t_pool - t_imap_start).as_millis() as u64,
+            select_ms = (t_select - t_pool).as_millis() as u64,
+            fetch_ms = (t_fetch - t_select).as_millis() as u64,
+            store_ms = (t_store - t_fetch).as_millis() as u64,
+            parse_ms = (t_parse - t_store).as_millis() as u64,
+            total_ms = t_parse.as_millis() as u64,
             "Body fetched and stored"
         );
 

--- a/src/sync/body_worker.rs
+++ b/src/sync/body_worker.rs
@@ -25,6 +25,7 @@ pub struct FetchBodyRequest {
     pub uuid: String,
     pub account_id: String,
     pub folder_name: String,
+    pub priority: bool,
 }
 
 /// Body fetch worker that processes priority and background requests.
@@ -67,12 +68,14 @@ impl BodyWorker {
         loop {
             let request = tokio::select! {
                 biased;
-                Some(req) = self.priority_rx.recv() => {
+                Some(mut req) = self.priority_rx.recv() => {
                     debug!(uid = req.uid, uuid = %req.uuid, "Priority body request");
+                    req.priority = true;
                     req
                 }
-                Some(req) = self.background_rx.recv() => {
+                Some(mut req) = self.background_rx.recv() => {
                     debug!(uid = req.uid, uuid = %req.uuid, "Background body request");
+                    req.priority = false;
                     req
                 }
                 else => {
@@ -151,7 +154,11 @@ impl BodyWorker {
             "Fetching body from IMAP"
         );
         let t_imap_start = t0.elapsed();
-        let mut guard = self.pool.acquire(&req.account_id, &config, max_conns).await?;
+        let mut guard = if req.priority {
+            self.pool.acquire_priority(&req.account_id, &config, max_conns).await?
+        } else {
+            self.pool.acquire(&req.account_id, &config, max_conns).await?
+        };
         let t_pool = t0.elapsed();
         let session = guard.session();
 

--- a/src/sync/idle.rs
+++ b/src/sync/idle.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
 
+use async_imap::imap_proto::types::{AttributeValue, Response};
+
 use crate::app_event::AppEvent;
 use crate::event_bus::EventSender;
 use crate::goa::types::{AuthMethod, ImapConfig};
@@ -227,6 +229,13 @@ async fn run_idle_session<T>(
                     "IDLE notification received"
                 );
 
+                // Parse the notification to determine the appropriate action
+                let event = parse_idle_response(
+                    data.parsed(),
+                    account_id,
+                    folder_name,
+                );
+
                 session = match handle.done().await {
                     Ok(s) => s,
                     Err(e) => {
@@ -235,10 +244,7 @@ async fn run_idle_session<T>(
                     }
                 };
 
-                sender.send(AppEvent::IdleNotification {
-                    account_id: account_id.to_string(),
-                    folder_name: folder_name.to_string(),
-                });
+                sender.send(event);
             }
             Ok(async_imap::extensions::idle::IdleResponse::Timeout) => {
                 debug!(account_id, folder_name, "IDLE timeout, re-entering");
@@ -282,6 +288,53 @@ async fn poll_loop(
             account_id: account_id.to_string(),
             folder_name: folder_name.to_string(),
         });
+    }
+}
+
+/// Parse an IDLE notification into the appropriate AppEvent.
+///
+/// Fetch responses with UID + Flags are converted to `IdleFlagsChanged` for
+/// direct flag updates. Everything else (EXISTS, EXPUNGE) triggers a full
+/// `IdleNotification` → `sync_folder`.
+fn parse_idle_response(response: &Response<'_>, account_id: &str, folder_name: &str) -> AppEvent {
+    if let Response::Fetch(_seq, attrs) = response {
+        let mut uid = None;
+        let mut flags = Vec::new();
+        let mut has_flags = false;
+
+        for attr in attrs {
+            match attr {
+                AttributeValue::Uid(u) => uid = Some(*u),
+                AttributeValue::Flags(f) => {
+                    has_flags = true;
+                    flags = f.iter().map(|s: &std::borrow::Cow<'_, str>| s.to_string()).collect();
+                }
+                _ => {}
+            }
+        }
+
+        if let (Some(uid), true) = (uid, has_flags) {
+            let is_read = flags.iter().any(|f| f == "\\Seen");
+            let is_flagged = flags.iter().any(|f| f == "\\Flagged");
+            let is_answered = flags.iter().any(|f| f == "\\Answered");
+            let is_draft = flags.iter().any(|f| f == "\\Draft");
+
+            return AppEvent::IdleFlagsChanged {
+                account_id: account_id.to_string(),
+                folder_name: folder_name.to_string(),
+                uid,
+                is_read,
+                is_flagged,
+                is_answered,
+                is_draft,
+            };
+        }
+    }
+
+    // Default: trigger full differential sync
+    AppEvent::IdleNotification {
+        account_id: account_id.to_string(),
+        folder_name: folder_name.to_string(),
     }
 }
 

--- a/src/sync/idle.rs
+++ b/src/sync/idle.rs
@@ -1,1 +1,295 @@
-// IMAP IDLE management
+//! IMAP IDLE manager — maintains persistent connections for real-time
+//! push notifications on prioritized folders.
+//!
+//! Each folder gets one long-lived tokio task that holds a dedicated IMAP
+//! connection (not from the pool). On server notification, the task emits
+//! an event that triggers differential sync via `sync_folder`.
+//!
+//! Fallback: when the server doesn't support IDLE, polls on a timer.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tracing::{debug, error, info, warn};
+
+use crate::app_event::AppEvent;
+use crate::event_bus::EventSender;
+use crate::goa::types::{AuthMethod, ImapConfig};
+use crate::sync::imap;
+use crate::sync::pool::ImapSession;
+
+/// How often to re-enter IDLE (RFC 2177 recommends before 29 min server timeout).
+const IDLE_TIMEOUT: Duration = Duration::from_secs(28 * 60);
+
+/// Maximum backoff delay on connection errors.
+const MAX_BACKOFF: Duration = Duration::from_secs(300);
+
+/// IDLE priority order — higher priority folders get IDLE first when budget is constrained.
+const IDLE_PRIORITY: &[&str] = &["inbox", "sent", "drafts", "archive", "trash"];
+
+/// Auth provider closure type — returns fresh credentials (handles OAuth token refresh).
+pub type AuthProvider =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<AuthMethod>> + Send>> + Send + Sync>;
+
+/// Manages IDLE tasks across all accounts.
+pub struct IdleManager {
+    tasks: HashMap<(String, String), tokio::task::JoinHandle<()>>,
+    shutdown: Arc<Notify>,
+}
+
+impl IdleManager {
+    pub fn new() -> Self {
+        Self {
+            tasks: HashMap::new(),
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Start IDLE or poll tasks for an account's folders, respecting connection budget.
+    pub fn start_for_account(
+        &mut self,
+        account_id: &str,
+        folders: &[(String, Option<String>)], // (folder_name, role)
+        config: ImapConfig,
+        auth_provider: AuthProvider,
+        idle_budget: usize,
+        supports_idle: bool,
+        poll_interval: Duration,
+        sender: EventSender,
+    ) {
+        // Sort folders by IDLE priority
+        let mut prioritized: Vec<_> = folders.to_vec();
+        prioritized.sort_by_key(|(_, role)| {
+            role.as_deref()
+                .and_then(|r| IDLE_PRIORITY.iter().position(|p| *p == r))
+                .unwrap_or(IDLE_PRIORITY.len())
+        });
+
+        for (i, (folder_name, role)) in prioritized.iter().enumerate() {
+            let key = (account_id.to_string(), folder_name.clone());
+            if self.tasks.contains_key(&key) {
+                continue;
+            }
+
+            let use_idle = supports_idle && i < idle_budget;
+
+            let account_id = account_id.to_string();
+            let folder_name = folder_name.clone();
+            let config = config.clone();
+            let auth_provider = Arc::clone(&auth_provider);
+            let sender = sender.clone();
+            let shutdown = Arc::clone(&self.shutdown);
+
+            if use_idle {
+                info!(
+                    account_id = %account_id,
+                    folder = %folder_name,
+                    role = ?role,
+                    "Starting IDLE task"
+                );
+
+                let handle = tokio::spawn(async move {
+                    idle_loop(&account_id, &folder_name, &config, auth_provider, sender, shutdown)
+                        .await;
+                });
+
+                self.tasks.insert(key, handle);
+            } else {
+                info!(
+                    account_id = %account_id,
+                    folder = %folder_name,
+                    role = ?role,
+                    interval_secs = poll_interval.as_secs(),
+                    reason = if !supports_idle { "no IDLE capability" } else { "over budget" },
+                    "Starting poll task"
+                );
+
+                let handle = tokio::spawn(async move {
+                    poll_loop(&account_id, &folder_name, poll_interval, sender, shutdown).await;
+                });
+
+                self.tasks.insert(key, handle);
+            }
+        }
+    }
+
+    /// Signal all IDLE/poll tasks to shut down.
+    pub fn shutdown(&self) {
+        info!("Shutting down IDLE manager");
+        self.shutdown.notify_waiters();
+    }
+}
+
+/// Core IDLE loop for a single folder. Reconnects with exponential backoff.
+async fn idle_loop(
+    account_id: &str,
+    folder_name: &str,
+    config: &ImapConfig,
+    auth_provider: AuthProvider,
+    sender: EventSender,
+    shutdown: Arc<Notify>,
+) {
+    let mut backoff = Duration::from_secs(1);
+
+    loop {
+        // Get fresh auth (tokens may have expired)
+        let auth = match (auth_provider)().await {
+            Ok(a) => a,
+            Err(e) => {
+                error!(account_id, folder_name, error = %e, "Failed to get auth for IDLE");
+                if !sleep_or_shutdown(backoff, &shutdown).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        // Connect
+        let session = match imap::connect(config, &auth).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(account_id, folder_name, error = %e, "IDLE connection failed, retrying");
+                if !sleep_or_shutdown(backoff, &shutdown).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        // Reset backoff on successful connect
+        backoff = Duration::from_secs(1);
+        info!(account_id, folder_name, "IDLE connection established");
+
+        // Run the IDLE session — dispatch to concrete transport type
+        match session {
+            ImapSession::Tls(s) => {
+                run_idle_session(s, account_id, folder_name, &sender, &shutdown).await;
+            }
+            ImapSession::Plain(s) => {
+                run_idle_session(s, account_id, folder_name, &sender, &shutdown).await;
+            }
+        }
+
+        debug!(account_id, folder_name, "IDLE session ended, will reconnect");
+    }
+}
+
+/// Run IDLE on a concrete session type. Loops: SELECT → IDLE → wait → emit → DONE → repeat.
+async fn run_idle_session<T>(
+    mut session: async_imap::Session<T>,
+    account_id: &str,
+    folder_name: &str,
+    sender: &EventSender,
+    shutdown: &Arc<Notify>,
+) where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + std::fmt::Debug + Send,
+{
+    if let Err(e) = session.select(folder_name).await {
+        error!(account_id, folder_name, error = %e, "Failed to SELECT for IDLE");
+        return;
+    }
+
+    loop {
+        // Enter IDLE — consumes the session
+        let mut handle = session.idle();
+        if let Err(e) = handle.init().await {
+            error!(account_id, folder_name, error = %e, "Failed to init IDLE");
+            return;
+        }
+
+        debug!(account_id, folder_name, "Entered IDLE");
+
+        // Wait for notification or timeout
+        let (idle_fut, stop_source) = handle.wait_with_timeout(IDLE_TIMEOUT);
+
+        // Spawn a task that drops the StopSource on shutdown, interrupting IDLE
+        let shutdown_clone = Arc::clone(shutdown);
+        let interrupt_task = tokio::spawn(async move {
+            shutdown_clone.notified().await;
+            drop(stop_source);
+        });
+
+        let response = idle_fut.await;
+        interrupt_task.abort();
+
+        match response {
+            Ok(async_imap::extensions::idle::IdleResponse::NewData(data)) => {
+                debug!(
+                    account_id,
+                    folder_name,
+                    response = ?data.parsed(),
+                    "IDLE notification received"
+                );
+
+                session = match handle.done().await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!(account_id, folder_name, error = %e, "Failed to exit IDLE");
+                        return;
+                    }
+                };
+
+                sender.send(AppEvent::IdleNotification {
+                    account_id: account_id.to_string(),
+                    folder_name: folder_name.to_string(),
+                });
+            }
+            Ok(async_imap::extensions::idle::IdleResponse::Timeout) => {
+                debug!(account_id, folder_name, "IDLE timeout, re-entering");
+                session = match handle.done().await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!(account_id, folder_name, error = %e, "Failed to exit IDLE after timeout");
+                        return;
+                    }
+                };
+            }
+            Ok(async_imap::extensions::idle::IdleResponse::ManualInterrupt) => {
+                debug!(account_id, folder_name, "IDLE interrupted (shutdown)");
+                let _ = handle.done().await;
+                return;
+            }
+            Err(e) => {
+                error!(account_id, folder_name, error = %e, "IDLE error");
+                return;
+            }
+        }
+    }
+}
+
+/// Poll loop fallback for servers without IDLE capability.
+async fn poll_loop(
+    account_id: &str,
+    folder_name: &str,
+    interval: Duration,
+    sender: EventSender,
+    shutdown: Arc<Notify>,
+) {
+    loop {
+        if !sleep_or_shutdown(interval, &shutdown).await {
+            debug!(account_id, folder_name, "Poll task shutting down");
+            return;
+        }
+
+        debug!(account_id, folder_name, "Poll timer fired");
+        sender.send(AppEvent::IdleNotification {
+            account_id: account_id.to_string(),
+            folder_name: folder_name.to_string(),
+        });
+    }
+}
+
+/// Sleep for `duration`, returning `true` if completed, `false` if shutdown.
+async fn sleep_or_shutdown(duration: Duration, shutdown: &Arc<Notify>) -> bool {
+    tokio::select! {
+        biased;
+        _ = shutdown.notified() => false,
+        _ = tokio::time::sleep(duration) => true,
+    }
+}

--- a/src/sync/pool.rs
+++ b/src/sync/pool.rs
@@ -84,6 +84,13 @@ impl ImapSession {
         }
     }
 
+    pub async fn capabilities(&mut self) -> Result<async_imap::types::Capabilities, ImapError> {
+        match self {
+            Self::Tls(s) => Ok(s.capabilities().await?),
+            Self::Plain(s) => Ok(s.capabilities().await?),
+        }
+    }
+
     pub async fn uid_search(&mut self, query: &str) -> Result<std::collections::HashSet<u32>, ImapError> {
         match self {
             Self::Tls(s) => Ok(s.uid_search(query).await?),

--- a/src/sync/pool.rs
+++ b/src/sync/pool.rs
@@ -139,18 +139,27 @@ impl PooledConnection {
 
 // ── AccountPool ────────────────────────────────────────────────────────────
 
+/// Number of connections reserved for priority operations (user-initiated body fetch).
+const RESERVED_PRIORITY_CONNECTIONS: usize = 2;
+
 /// Pool of IMAP connections for a single account.
 struct AccountPool {
     account_id: String,
+    /// Semaphore for general (background) operations.
     semaphore: Arc<Semaphore>,
+    /// Semaphore for priority (user-initiated) operations — always has permits.
+    priority_semaphore: Arc<Semaphore>,
     idle_connections: std::sync::Mutex<Vec<PooledConnection>>,
 }
 
 impl AccountPool {
     fn new(account_id: String, max_connections: usize) -> Self {
+        let reserved = RESERVED_PRIORITY_CONNECTIONS.min(max_connections.saturating_sub(1));
+        let general = max_connections.saturating_sub(reserved);
         Self {
             account_id,
-            semaphore: Arc::new(Semaphore::new(max_connections)),
+            semaphore: Arc::new(Semaphore::new(general)),
+            priority_semaphore: Arc::new(Semaphore::new(reserved)),
             idle_connections: std::sync::Mutex::new(Vec::new()),
         }
     }
@@ -293,6 +302,55 @@ impl SyncTaskPool {
         let session = crate::sync::imap::connect(config, &auth).await?;
 
         debug!(account_id, host = %config.host, "Created new pooled IMAP connection");
+
+        Ok(ConnectionGuard {
+            connection: Some(PooledConnection::new(session)),
+            pool: account_pool,
+            _permit: permit,
+            poisoned: false,
+        })
+    }
+
+    /// Acquire a priority connection — uses reserved permits that are never
+    /// blocked by background sync operations.
+    pub async fn acquire_priority(
+        &self,
+        account_id: &str,
+        config: &ImapConfig,
+        max_connections: usize,
+    ) -> Result<ConnectionGuard, ImapError> {
+        let account_pool = self.get_or_create_pool(account_id, max_connections);
+
+        let permit = account_pool
+            .priority_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("priority semaphore closed");
+
+        // Try to reuse an idle connection
+        if let Some(mut conn) = account_pool.take_idle() {
+            match conn.session.noop().await {
+                Ok(()) => {
+                    debug!(account_id, "Reusing pooled connection (priority)");
+                    return Ok(ConnectionGuard {
+                        connection: Some(conn),
+                        pool: account_pool,
+                        _permit: permit,
+                        poisoned: false,
+                    });
+                }
+                Err(e) => {
+                    debug!(account_id, error = %e, "Pooled connection failed health check (priority)");
+                }
+            }
+        }
+
+        let auth = self.goa.lock().await.get_imap_auth(account_id).await
+            .map_err(|e| ImapError::Auth(e.to_string()))?;
+        let session = crate::sync::imap::connect(config, &auth).await?;
+
+        debug!(account_id, host = %config.host, "Created new pooled connection (priority)");
 
         Ok(ConnectionGuard {
             connection: Some(PooledConnection::new(session)),

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -9,6 +9,7 @@ use gtk::prelude::*;
 use tokio::sync::mpsc;
 
 use crate::app_event::AppEvent;
+use crate::engine::body_store::BodyStore;
 use crate::engine::pipeline::EmailPipeline;
 use crate::engine::traits::accounts::{Account, MailAccounts};
 use crate::engine::traits::folders::{Folder, MailFolders};
@@ -39,6 +40,7 @@ pub struct SyncEngine {
     accounts: Arc<dyn MailAccounts>,
     folders: Arc<dyn MailFolders>,
     messages: Arc<dyn MailMessages>,
+    body_store: Arc<BodyStore>,
     #[allow(dead_code)] // Used for IDLE notifications and sync progress events
     sender: EventSender,
     pipeline: EmailPipeline,
@@ -71,6 +73,7 @@ impl SyncEngine {
         let body_store = engine.body_store();
         let sender = engine.sender();
         let prefetch_days = settings.int("sync-body-prefetch-days").max(0) as u32;
+        let body_store_for_engine = Arc::clone(&body_store);
         let poll_interval_minutes = settings.int("sync-poll-interval-minutes").max(1) as u32;
 
         let goa = Arc::new(tokio::sync::Mutex::new(GoaClient::new().await?));
@@ -100,6 +103,7 @@ impl SyncEngine {
             accounts,
             folders,
             messages,
+            body_store: body_store_for_engine,
             sender,
             pipeline: EmailPipeline::new(),
             running: std::sync::atomic::AtomicBool::new(false),
@@ -415,13 +419,13 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Queue body fetches for messages within the prefetch window that may be
+    /// Queue body fetches for messages within the prefetch window that are
     /// missing .eml files (e.g., app was quit before prefetch completed).
-    /// The body worker checks disk before fetching, so duplicates are harmless.
     async fn backfill_missing_bodies(&self, accounts: &[Account]) {
         let cutoff = chrono::Utc::now() - chrono::Duration::days(self.prefetch_days as i64);
         let cutoff_str = cutoff.to_rfc3339();
         let mut queued = 0u32;
+        let mut skipped = 0u32;
 
         for account in accounts {
             let folders = match self.folders.list_folders(&account.goa_id).await {
@@ -440,6 +444,12 @@ impl SyncEngine {
                 };
 
                 for (uuid, uid, _date) in messages {
+                    // Only queue if .eml is missing on disk
+                    if self.body_store.has_eml(&account.goa_id, &uuid).await {
+                        skipped += 1;
+                        continue;
+                    }
+
                     let _ = self.body_background_tx.try_send(FetchBodyRequest {
                         uid,
                         uuid,
@@ -451,8 +461,8 @@ impl SyncEngine {
             }
         }
 
-        if queued > 0 {
-            info!(queued, prefetch_days = self.prefetch_days, "Queued body backfill");
+        if queued > 0 || skipped > 0 {
+            info!(queued, skipped, prefetch_days = self.prefetch_days, "Body backfill complete");
         }
     }
 

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -156,6 +156,24 @@ impl SyncEngine {
                         }
                     });
                 }
+                AppEvent::IdleFlagsChanged { account_id, folder_name, uid, is_read, is_flagged, is_answered, is_draft } => {
+                    let engine = Arc::clone(&engine);
+                    let account_id = account_id.clone();
+                    let folder_name = folder_name.clone();
+                    let uid = *uid;
+                    let is_read = *is_read;
+                    let is_flagged = *is_flagged;
+                    let is_answered = *is_answered;
+                    let is_draft = *is_draft;
+                    tokio::spawn(async move {
+                        if let Err(e) = engine.messages.update_flags(
+                            &account_id, &folder_name, uid,
+                            is_read, is_flagged, is_answered, is_draft,
+                        ).await {
+                            error!(uid, error = %e, "Failed to update flags from IDLE");
+                        }
+                    });
+                }
                 AppEvent::MessageBodyRequested { account_id, folder_name, uid } => {
                     let engine = Arc::clone(&engine);
                     let account_id = account_id.clone();
@@ -600,6 +618,55 @@ impl SyncEngine {
             new
             // guard dropped — connection returned to pool
         };
+
+        // ── Stage 1b: Flag Sync ─────────────────────────────────────────
+        // Fetch flags for all existing UIDs and update any that changed.
+        {
+            let mut guard = self.pool.acquire(account_id, config, max_conns).await?;
+            let session = guard.session();
+            session.select(folder_name).await?;
+
+            let fetches = match session.uid_fetch("1:*", "(UID FLAGS)").await {
+                Ok(f) => f,
+                Err(e) => {
+                    guard.poison();
+                    return Err(e.into());
+                }
+            };
+
+            let mut flag_updates = 0u32;
+            for fetch in &fetches {
+                if let Some(uid) = fetch.uid {
+                    let flags: Vec<String> = fetch
+                        .flags()
+                        .map(|f| match f {
+                            async_imap::types::Flag::Seen => "\\Seen".to_string(),
+                            async_imap::types::Flag::Answered => "\\Answered".to_string(),
+                            async_imap::types::Flag::Flagged => "\\Flagged".to_string(),
+                            async_imap::types::Flag::Draft => "\\Draft".to_string(),
+                            _ => String::new(),
+                        })
+                        .collect();
+
+                    let is_read = flags.iter().any(|f| f == "\\Seen");
+                    let is_flagged = flags.iter().any(|f| f == "\\Flagged");
+                    let is_answered = flags.iter().any(|f| f == "\\Answered");
+                    let is_draft = flags.iter().any(|f| f == "\\Draft");
+
+                    if let Ok(true) = self
+                        .messages
+                        .update_flags(account_id, folder_name, uid, is_read, is_flagged, is_answered, is_draft)
+                        .await
+                    {
+                        flag_updates += 1;
+                    }
+                }
+            }
+
+            if flag_updates > 0 {
+                debug!(account_id, folder_name, flag_updates, "Flag sync complete");
+            }
+        }
 
         if new_uids.is_empty() {
             return Ok(());

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -310,6 +310,10 @@ impl SyncEngine {
 
         futures::future::join_all(futures).await;
 
+        // Start IDLE immediately after folder discovery — don't wait for
+        // message sync to complete. IDLE on Inbox should be active ASAP.
+        self.start_idle(&domain_accounts).await;
+
         // ── Sync messages for all folders ────────────────────────────────
         // Two-stage pipeline per folder:
         //   Stage 1 (ID sync): uid_search → diff → delete removed
@@ -376,10 +380,7 @@ impl SyncEngine {
             self.backfill_missing_bodies(&domain_accounts).await;
         }
 
-        // Start IDLE connections for real-time push notifications.
-        self.start_idle(&domain_accounts).await;
-
-        info!("Initial sync complete — IDLE active");
+        info!("Initial sync complete");
         Ok(())
     }
 

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -157,6 +157,14 @@ impl SyncEngine {
                     });
                 }
                 AppEvent::IdleFlagsChanged { account_id, folder_name, uid, is_read, is_flagged, is_answered, is_draft } => {
+                    debug!(
+                        uid,
+                        is_read,
+                        is_flagged,
+                        account_id = %account_id,
+                        folder_name = %folder_name,
+                        "Received IdleFlagsChanged event"
+                    );
                     let engine = Arc::clone(&engine);
                     let account_id = account_id.clone();
                     let folder_name = folder_name.clone();
@@ -166,11 +174,16 @@ impl SyncEngine {
                     let is_answered = *is_answered;
                     let is_draft = *is_draft;
                     tokio::spawn(async move {
-                        if let Err(e) = engine.messages.update_flags(
+                        match engine.messages.update_flags(
                             &account_id, &folder_name, uid,
                             is_read, is_flagged, is_answered, is_draft,
                         ).await {
-                            error!(uid, error = %e, "Failed to update flags from IDLE");
+                            Ok(changed) => {
+                                debug!(uid, changed, "Flag update result");
+                            }
+                            Err(e) => {
+                                error!(uid, error = %e, "Failed to update flags from IDLE");
+                            }
                         }
                     });
                 }

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -221,6 +221,7 @@ impl SyncEngine {
                             uuid,
                             account_id,
                             folder_name,
+                            priority: true,
                         }).await {
                             error!(error = %e, "Failed to send priority body request");
                         }
@@ -455,6 +456,7 @@ impl SyncEngine {
                         uuid,
                         account_id: account.goa_id.clone(),
                         folder_name: folder.name.clone(),
+                        priority: false,
                     });
                     queued += 1;
                 }
@@ -788,6 +790,7 @@ impl SyncEngine {
                             uuid: msg.uuid.clone(),
                             account_id: account_id.to_string(),
                             folder_name: folder_name.to_string(),
+                            priority: false,
                         });
                     }
                 }

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tracing::{debug, error, info, warn};
 
@@ -17,6 +18,7 @@ use crate::event_bus::EventSender;
 use crate::goa::types::{GoaMailAccount, ImapConfig, TlsMode};
 use crate::goa::GoaClient;
 use crate::sync::body_worker::{BodyWorker, FetchBodyRequest};
+use crate::sync::idle::IdleManager;
 use crate::sync::imap::ImapFolder;
 use crate::sync::pool::{max_connections_for_provider, SyncTaskPool};
 
@@ -51,6 +53,10 @@ pub struct SyncEngine {
     body_background_tx: mpsc::Sender<FetchBodyRequest>,
     /// Number of days of message bodies to prefetch. 0 = disabled.
     prefetch_days: u32,
+    /// Poll interval for servers without IDLE support.
+    poll_interval_minutes: u32,
+    /// IDLE manager — started after initial sync completes.
+    idle_manager: tokio::sync::Mutex<IdleManager>,
 }
 
 impl SyncEngine {
@@ -65,6 +71,7 @@ impl SyncEngine {
         let body_store = engine.body_store();
         let sender = engine.sender();
         let prefetch_days = settings.int("sync-body-prefetch-days").max(0) as u32;
+        let poll_interval_minutes = settings.int("sync-poll-interval-minutes").max(1) as u32;
 
         let goa = Arc::new(tokio::sync::Mutex::new(GoaClient::new().await?));
         let pool = Arc::new(SyncTaskPool::new(Arc::clone(&goa)));
@@ -101,6 +108,8 @@ impl SyncEngine {
             body_priority_tx,
             body_background_tx,
             prefetch_days,
+            poll_interval_minutes,
+            idle_manager: tokio::sync::Mutex::new(IdleManager::new()),
         }))
     }
 
@@ -127,8 +136,24 @@ impl SyncEngine {
                     info!("Shutting down sync engine");
                     let engine = Arc::clone(&engine);
                     tokio::spawn(async move {
+                        engine.idle_manager.lock().await.shutdown();
                         engine.pool.shutdown().await;
                         engine.stop();
+                    });
+                }
+                AppEvent::IdleNotification { account_id, folder_name } => {
+                    let engine = Arc::clone(&engine);
+                    let account_id = account_id.clone();
+                    let folder_name = folder_name.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = engine.handle_idle_notification(&account_id, &folder_name).await {
+                            error!(
+                                account_id = %account_id,
+                                folder_name = %folder_name,
+                                error = %e,
+                                "IDLE-triggered sync failed"
+                            );
+                        }
                     });
                 }
                 AppEvent::MessageBodyRequested { account_id, folder_name, uid } => {
@@ -347,12 +372,14 @@ impl SyncEngine {
         }
 
         // Queue body prefetch for messages within the window that may be missing .eml files.
-        // The body worker will skip messages that already have files on disk.
         if self.prefetch_days > 0 {
             self.backfill_missing_bodies(&domain_accounts).await;
         }
 
-        info!("Initial sync complete");
+        // Start IDLE connections for real-time push notifications.
+        self.start_idle(&domain_accounts).await;
+
+        info!("Initial sync complete — IDLE active");
         Ok(())
     }
 
@@ -394,6 +421,129 @@ impl SyncEngine {
 
         if queued > 0 {
             info!(queued, prefetch_days = self.prefetch_days, "Queued body backfill");
+        }
+    }
+
+    /// Handle an IDLE or poll notification — run sync_folder for the specified folder.
+    async fn handle_idle_notification(
+        &self,
+        account_id: &str,
+        folder_name: &str,
+    ) -> anyhow::Result<()> {
+        debug!(account_id, folder_name, "IDLE notification — running sync");
+
+        let config = {
+            let configs = self.imap_configs.read().await;
+            configs.get(account_id).cloned()
+        };
+        let config = match config {
+            Some(c) => c,
+            None => {
+                warn!(account_id, "No cached IMAP config for IDLE sync");
+                return Ok(());
+            }
+        };
+
+        let max_conns = {
+            let providers = self.provider_types.read().await;
+            providers
+                .get(account_id)
+                .map(|p| max_connections_for_provider(p))
+                .unwrap_or(10)
+        };
+
+        self.sync_folder(account_id, folder_name, &config, max_conns)
+            .await
+    }
+
+    /// Start IDLE connections for all accounts after initial sync completes.
+    async fn start_idle(&self, accounts: &[Account]) {
+        let mut idle_mgr = self.idle_manager.lock().await;
+        let poll_interval = Duration::from_secs(self.poll_interval_minutes as u64 * 60);
+
+        for account in accounts {
+            let folders = match self.folders.list_folders(&account.goa_id).await {
+                Ok(f) => f,
+                Err(e) => {
+                    error!(email = %account.email_address, error = %e, "Failed to list folders for IDLE");
+                    continue;
+                }
+            };
+
+            let folder_list: Vec<(String, Option<String>)> = folders
+                .iter()
+                .map(|f| (f.name.clone(), f.role.clone()))
+                .collect();
+
+            let config = {
+                let configs = self.imap_configs.read().await;
+                configs.get(&account.goa_id).cloned()
+            };
+            let config = match config {
+                Some(c) => c,
+                None => continue,
+            };
+
+            let max_conns = {
+                let providers = self.provider_types.read().await;
+                providers
+                    .get(&account.goa_id)
+                    .map(|p| max_connections_for_provider(p))
+                    .unwrap_or(10)
+            };
+
+            // Check IDLE capability
+            let supports_idle = match self.pool.acquire(&account.goa_id, &config, max_conns).await {
+                Ok(mut guard) => {
+                    match guard.session().capabilities().await {
+                        Ok(caps) => caps.has_str("IDLE"),
+                        Err(e) => {
+                            warn!(email = %account.email_address, error = %e, "Failed to check capabilities");
+                            guard.poison();
+                            false
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(email = %account.email_address, error = %e, "Failed to acquire connection for capability check");
+                    false
+                }
+            };
+
+            // IDLE budget: provider limit - 2 (reserve for pool operations)
+            let idle_budget = max_conns.saturating_sub(2).max(1);
+
+            info!(
+                email = %account.email_address,
+                supports_idle,
+                idle_budget,
+                "Configuring IDLE/poll for account"
+            );
+
+            // Build auth provider closure
+            let goa = Arc::clone(&self.goa);
+            let goa_id = account.goa_id.clone();
+            let auth_provider: crate::sync::idle::AuthProvider = Arc::new(move || {
+                let goa = Arc::clone(&goa);
+                let goa_id = goa_id.clone();
+                Box::pin(async move {
+                    let goa = goa.lock().await;
+                    goa.get_imap_auth(&goa_id)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                })
+            });
+
+            idle_mgr.start_for_account(
+                &account.goa_id,
+                &folder_list,
+                config,
+                auth_provider,
+                idle_budget,
+                supports_idle,
+                poll_interval,
+                self.sender.clone(),
+            );
         }
     }
 

--- a/src/sync/service.rs
+++ b/src/sync/service.rs
@@ -9,7 +9,6 @@ use gtk::prelude::*;
 use tokio::sync::mpsc;
 
 use crate::app_event::AppEvent;
-use crate::engine::body_store::BodyStore;
 use crate::engine::pipeline::EmailPipeline;
 use crate::engine::traits::accounts::{Account, MailAccounts};
 use crate::engine::traits::folders::{Folder, MailFolders};
@@ -40,7 +39,6 @@ pub struct SyncEngine {
     accounts: Arc<dyn MailAccounts>,
     folders: Arc<dyn MailFolders>,
     messages: Arc<dyn MailMessages>,
-    body_store: Arc<BodyStore>,
     #[allow(dead_code)] // Used for IDLE notifications and sync progress events
     sender: EventSender,
     pipeline: EmailPipeline,
@@ -73,7 +71,6 @@ impl SyncEngine {
         let body_store = engine.body_store();
         let sender = engine.sender();
         let prefetch_days = settings.int("sync-body-prefetch-days").max(0) as u32;
-        let body_store_for_engine = Arc::clone(&body_store);
         let poll_interval_minutes = settings.int("sync-poll-interval-minutes").max(1) as u32;
 
         let goa = Arc::new(tokio::sync::Mutex::new(GoaClient::new().await?));
@@ -103,7 +100,6 @@ impl SyncEngine {
             accounts,
             folders,
             messages,
-            body_store: body_store_for_engine,
             sender,
             pipeline: EmailPipeline::new(),
             running: std::sync::atomic::AtomicBool::new(false),
@@ -188,6 +184,17 @@ impl SyncEngine {
                             Err(e) => {
                                 error!(uid, error = %e, "Failed to update flags from IDLE");
                             }
+                        }
+                    });
+                }
+                AppEvent::MessageBodyFetched { account_id, folder_name, uid, .. } => {
+                    let engine = Arc::clone(&engine);
+                    let account_id = account_id.clone();
+                    let folder_name = folder_name.clone();
+                    let uid = *uid;
+                    tokio::spawn(async move {
+                        if let Err(e) = engine.messages.mark_body_downloaded(&account_id, &folder_name, uid).await {
+                            error!(uid, error = %e, "Failed to mark body as downloaded");
                         }
                     });
                 }
@@ -420,12 +427,11 @@ impl SyncEngine {
     }
 
     /// Queue body fetches for messages within the prefetch window that are
-    /// missing .eml files (e.g., app was quit before prefetch completed).
+    /// missing bodies (has_body = false in DB).
     async fn backfill_missing_bodies(&self, accounts: &[Account]) {
         let cutoff = chrono::Utc::now() - chrono::Duration::days(self.prefetch_days as i64);
         let cutoff_str = cutoff.to_rfc3339();
         let mut queued = 0u32;
-        let mut skipped = 0u32;
 
         for account in accounts {
             let folders = match self.folders.list_folders(&account.goa_id).await {
@@ -434,22 +440,16 @@ impl SyncEngine {
             };
 
             for folder in &folders {
-                let messages = match self
+                let missing = match self
                     .messages
-                    .list_messages_since(&account.goa_id, &folder.name, &cutoff_str)
+                    .list_missing_bodies(&account.goa_id, &folder.name, &cutoff_str)
                     .await
                 {
                     Ok(m) => m,
                     Err(_) => continue,
                 };
 
-                for (uuid, uid, _date) in messages {
-                    // Only queue if .eml is missing on disk
-                    if self.body_store.has_eml(&account.goa_id, &uuid).await {
-                        skipped += 1;
-                        continue;
-                    }
-
+                for (uuid, uid) in missing {
                     let _ = self.body_background_tx.try_send(FetchBodyRequest {
                         uid,
                         uuid,
@@ -461,8 +461,8 @@ impl SyncEngine {
             }
         }
 
-        if queued > 0 || skipped > 0 {
-            info!(queued, skipped, prefetch_days = self.prefetch_days, "Body backfill complete");
+        if queued > 0 {
+            info!(queued, prefetch_days = self.prefetch_days, "Queued body backfill");
         }
     }
 

--- a/src/ui/message_list/message_list.rs
+++ b/src/ui/message_list/message_list.rs
@@ -464,6 +464,12 @@ impl EpistleMessageList {
                 if store.n_items() > 0 {
                     self.imp().stack.set_visible_child_name("list");
                 }
+
+                // Auto-scroll to top if user is already near the top
+                let vadj = self.imp().scrolled_window.vadjustment();
+                if vadj.value() < 50.0 {
+                    vadj.set_value(0.0);
+                }
             }
         }
     }

--- a/src/ui/message_view/message_view.rs
+++ b/src/ui/message_view/message_view.rs
@@ -35,6 +35,9 @@ mod imp {
         /// HTML body served by the `epistle:` URI scheme handler.
         pub(super) current_html: Rc<RefCell<String>>,
 
+        /// Timestamp of when body was requested (for latency measurement).
+        pub(super) body_request_time: RefCell<Option<std::time::Instant>>,
+
         // Header widgets (added dynamically to content_box)
         pub(super) header_box: std::cell::OnceCell<gtk::Box>,
         pub(super) subject_label: std::cell::OnceCell<gtk::Label>,
@@ -160,6 +163,9 @@ impl EpistleMessageView {
             .expect("sender set before use")
             .clone();
 
+        let t = std::time::Instant::now();
+        *self.imp().body_request_time.borrow_mut() = Some(t);
+
         tracing::debug!(uid, "Requesting body fetch");
         sender.send(AppEvent::MessageBodyRequested {
             account_id: account_id.to_string(),
@@ -207,7 +213,9 @@ impl EpistleMessageView {
                         && *imp.current_account_id.borrow() == *account_id
                         && *imp.current_folder.borrow() == *folder_name
                     {
-                        tracing::debug!(uid, "Body fetched, rendering");
+                        let latency = view.imp().body_request_time.borrow()
+                            .map(|t| t.elapsed().as_millis() as u64);
+                        tracing::debug!(uid, latency_ms = ?latency, "Body fetched, rendering");
                         view.render_body(body);
                     }
                 }


### PR DESCRIPTION
## Summary

- IDLE manager with one persistent connection per folder (not from pool)
- Prioritized: Inbox > Sent > Drafts > Archive > Trash
- Budget: `provider_limit - 2`, surplus folders fall back to polling
- 28-min IDLE timeout cycle per RFC 2177
- Exponential backoff on connection errors (1s → 5 min cap)
- Poll fallback for servers without IDLE capability (GSettings interval)
- OAuth token refresh on reconnect via auth provider closure
- Clean shutdown via `tokio::sync::Notify` + `StopSource` interrupt

## Flow

```
IDLE notification → IdleNotification event → SyncEngine.sync_folder()
                                                    ↓
                                        ID sync → header fetch → body prefetch
```

Closes #62

## Test plan

- [x] `make check` — clean build
- [x] `make test` — 33 tests pass
- [ ] `make debug` — verify IDLE tasks start, notifications trigger sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)